### PR TITLE
Update libitpp.lwr

### DIFF
--- a/libitpp.lwr
+++ b/libitpp.lwr
@@ -18,7 +18,7 @@
 #
 
 category: baseline
-inherit: autoconf
+inherit: cmake
 satisfy:
   deb: libitpp-dev
   rpm: itpp-devel


### PR DESCRIPTION
It is recommended to build IT++ by cmake since version 4.3.0.

And the autoconf way may encounter "subdir-objects" problem and will be obsoleted.

>  They might be removed in the future.

refer to : [IT++ Installation](http://itpp.sourceforge.net/4.3.1/installation.html)